### PR TITLE
Autocomplete improvements, Table tooltip and popper example

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weng-lab/ui-components",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "description": "React MUI components for the Weng/Moore Labs suite of genomics web resources",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weng-lab/ui-components",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "React MUI components for the Weng/Moore Labs suite of genomics web resources",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weng-lab/ui-components",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "React MUI components for the Weng/Moore Labs suite of genomics web resources",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/ui-components/src/components/GenomeSearch/GenomeSearch.stories.tsx
+++ b/packages/ui-components/src/components/GenomeSearch/GenomeSearch.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import GenomeSearch from "./GenomeSearch";
 import { Result } from "./types";
-import { Button, TextField } from "@mui/material";
+import { Button, FormControl, InputLabel, MenuItem, Select, Stack, TextField, Typography } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
-import React from "react";
+import React, { useState } from "react";
 
 const meta = {
   title: "ui-components/GenomeSearch",
@@ -98,3 +98,52 @@ export const ButtonAndInputSlot: Story = {
     slotProps: {},
   },
 };
+
+export const ClearOnAssemblyChange: Story = {
+  args: {
+    assembly: "GRCh38",
+    onSearchSubmit: (r: Result) => console.log("Going to", r.title),
+    queries: ["Gene", "SNP", "iCRE", "cCRE", "Coordinate"],
+    ccreLimit: 3,
+    geneLimit: 3,
+    icreLimit: 3,
+    snpLimit: 3,
+    style: {},
+    sx: { width: 400 },
+    slots: {},
+    slotProps: {
+      button: {
+        variant: "contained",
+        startIcon: <SearchIcon />,
+        color: "secondary",
+        children: "Search",
+        sx: { paddingInline: 3 },
+      },
+    },
+  },
+  render: (args) => {
+    const [assembly, setAssembly] = useState<"GRCh38" | "mm10">("GRCh38")
+
+    const {assembly: unused, ...Autocompleteprops} = args
+
+    return (
+      <Stack maxWidth={400} spacing={2}>
+        <FormControl>
+          <InputLabel id="demo-simple-select-label">Assembly</InputLabel>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            value={assembly}
+            label="Assembly"
+            onChange={(e) => setAssembly(e.target.value)}
+          >
+            <MenuItem value={"GRCh38"}>GRCh38</MenuItem>
+            <MenuItem value={"mm10"}>mm10</MenuItem>
+          </Select>
+        </FormControl>
+        <Typography>The assembly passed to component is: {assembly}</Typography>
+        <GenomeSearch assembly={assembly} {...Autocompleteprops} />
+      </Stack>
+    );
+  },
+}

--- a/packages/ui-components/src/components/GenomeSearch/GenomeSearch.tsx
+++ b/packages/ui-components/src/components/GenomeSearch/GenomeSearch.tsx
@@ -34,7 +34,7 @@ const Search: React.FC<GenomeSearchProps> = ({
 }) => {
   // State variables
   const [inputValue, setInputValue] = useState("");
-  const [selection, setSelection] = useState<Result>({} as Result);
+  const [selection, setSelection] = useState<Result | null>(null);
   const [results, setResults] = useState<Result[] | null>(defaultResults || null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -168,35 +168,40 @@ const Search: React.FC<GenomeSearchProps> = ({
     snpLimit,
   ]);
 
+  //Clear input on assembly change
+  useEffect(() => {
+    setInputValue("")
+    setSelection(null)
+  }, [assembly])
+
   // Handle submit
   const onSubmit = useCallback(() => {
-    let sel = selection;
-    if (results?.length === 1) {
-      sel = results[0];
-    }
-    if (!sel?.title) return;
-    onSearchSubmit?.(sel);
-  }, [onSearchSubmit, selection, results]);
+    if (selection && onSearchSubmit) onSearchSubmit(selection);
+  }, [onSearchSubmit, selection]);
 
   // Handle enter key down
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key === "Enter") {
-        onSubmit();
+        const exactMatch = results?.find(x => x.title?.toLowerCase() === inputValue.toLowerCase())
+        if (exactMatch) {
+          setSelection(exactMatch)
+          if (onSearchSubmit) onSearchSubmit(exactMatch)
+        }
       }
     },
-    [onSubmit]
+    [results, setSelection, onSearchSubmit]
   );
 
-  const onChange = (_event: React.SyntheticEvent, newValue: Result | null) => {
-    let sel = newValue || ({} as Result);
-    setSelection(sel);
+  const onChange = (_event: React.SyntheticEvent<Element, Event>, newValue: Result) => {
+    setSelection(newValue);
   };
 
   return (
     <Box display="flex" flexDirection="row" gap={2} style={{ ...style }} sx={{ ...sx }} {...slotProps?.box}>
       <Autocomplete
         onChange={onChange}
+        value={selection as Result}
         options={inputValue === "" ? defaultResults || [] : results || []}
         getOptionLabel={(option: Result) => {
           return option.title || "";
@@ -204,6 +209,7 @@ const Search: React.FC<GenomeSearchProps> = ({
         groupBy={(option: Result) => option.type || ""}
         renderGroup={(params) => renderGroup(params, inputValue)}
         noOptionsText={noOptionsText(inputValue, isLoading, results)}
+        isOptionEqualToValue={(option, value) => option.title === value.title}
         renderOption={renderOptions}
         filterOptions={(x) => x}
         renderInput={(params) => {

--- a/packages/ui-components/src/components/GenomeSearch/GenomeSearch.tsx
+++ b/packages/ui-components/src/components/GenomeSearch/GenomeSearch.tsx
@@ -59,7 +59,7 @@ const Search: React.FC<GenomeSearchProps> = ({
     refetch: refetchCCREs,
     isFetching: ccreFetching,
   } = useQuery({
-    queryKey: ["ccres", inputValue],
+    queryKey: ["ccres", inputValue, assembly],
     queryFn: () => getCCREs(inputValue, assembly, ccreLimit || 3, showiCREFlag || false),
     enabled: false,
   });
@@ -68,7 +68,7 @@ const Search: React.FC<GenomeSearchProps> = ({
     refetch: refetchGenes,
     isFetching: geneFetching,
   } = useQuery({
-    queryKey: ["genes", inputValue],
+    queryKey: ["genes", inputValue, assembly],
     queryFn: () => getGenes(inputValue, assembly, geneLimit || 3, geneVersion || assembly === "GRCh38" ? 29 : 25),
     enabled: false,
   });
@@ -78,7 +78,7 @@ const Search: React.FC<GenomeSearchProps> = ({
     refetch: refetchSNPs,
     isFetching: snpFetching,
   } = useQuery({
-    queryKey: ["snps", inputValue],
+    queryKey: ["snps", inputValue, assembly],
     queryFn: () => getSNPs(inputValue, assembly, snpLimit || 3),
     enabled: false,
   });

--- a/packages/ui-components/src/components/Table/CustomToolbar.tsx
+++ b/packages/ui-components/src/components/Table/CustomToolbar.tsx
@@ -61,10 +61,10 @@ const StyledTextField = styled(TextField)<{
 type CustomToolbarProps = {
   label: DataGridProProps["label"];
   labelTooltip: TableProps["labelTooltip"];
-  extraComponentSlot?: React.ReactNode;
+  toolbarSlot?: React.ReactNode;
 };
 
-export function CustomToolbar({ label, labelTooltip, extraComponentSlot }: CustomToolbarProps) {
+export function CustomToolbar({ label, labelTooltip, toolbarSlot }: CustomToolbarProps) {
   const [exportMenuOpen, setExportMenuOpen] = React.useState(false);
   const exportMenuTriggerRef = React.useRef<HTMLButtonElement>(null);
 
@@ -82,9 +82,9 @@ export function CustomToolbar({ label, labelTooltip, extraComponentSlot }: Custo
         )}
       </Typography>
 
-      {extraComponentSlot && (
+      {toolbarSlot && (
         <>
-          {extraComponentSlot}
+          {toolbarSlot}
           <Divider orientation="vertical" variant="middle" flexItem sx={{ mx: 0.5 }} />
         </>
       )}

--- a/packages/ui-components/src/components/Table/CustomToolbar.tsx
+++ b/packages/ui-components/src/components/Table/CustomToolbar.tsx
@@ -26,6 +26,8 @@ import InputAdornment from "@mui/material/InputAdornment";
 import CancelIcon from "@mui/icons-material/Cancel";
 import SearchIcon from "@mui/icons-material/Search";
 import Typography from "@mui/material/Typography";
+import { TableProps } from "./types";
+import { InfoOutline } from "@mui/icons-material";
 
 type OwnerState = {
   expanded: boolean;
@@ -58,17 +60,26 @@ const StyledTextField = styled(TextField)<{
 
 type CustomToolbarProps = {
   label: DataGridProProps["label"];
+  labelTooltip: TableProps["labelTooltip"];
   extraComponentSlot?: React.ReactNode;
-}
+};
 
-export function CustomToolbar({ label, extraComponentSlot }: CustomToolbarProps) {
+export function CustomToolbar({ label, labelTooltip, extraComponentSlot }: CustomToolbarProps) {
   const [exportMenuOpen, setExportMenuOpen] = React.useState(false);
   const exportMenuTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   return (
     <Toolbar>
-      <Typography fontWeight="medium" sx={{ flex: 1, mx: 0.5 }}>
+      <Typography fontWeight="medium" sx={{ flex: 1, mx: 0.5, display: "flex", alignItems: "center", gap: 1 }}>
         {label}
+        {/* ReactNode can be more than just an element, string, or number but not accounting for that for simplicity */}
+        {labelTooltip && (typeof labelTooltip === "string" || typeof labelTooltip === "number") ? (
+          <Tooltip title={labelTooltip}>
+            <InfoOutline fontSize="inherit" color="primary" />
+          </Tooltip>
+        ) : (
+          labelTooltip
+        )}
       </Typography>
 
       {extraComponentSlot && (

--- a/packages/ui-components/src/components/Table/Table.stories.tsx
+++ b/packages/ui-components/src/components/Table/Table.stories.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react'
+import * as React from "react";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Table } from "../..";
 import { LicenseInfo } from "@mui/x-license";
 import { GridColDef } from "@mui/x-data-grid-pro";
-import { Box, Button, Popper, Tooltip } from "@mui/material";
+import { Box, Button, Popper, PopperProps, Stack, Tooltip, Typography } from "@mui/material";
 import { InfoOutline, QuestionMark } from "@mui/icons-material";
 
 const meta = {
@@ -16,9 +16,7 @@ const meta = {
   },
   decorators: [
     (Story) => {
-      LicenseInfo.setLicenseKey(
-        process.env.NEXT_PUBLIC_MUI_X_LICENSE_KEY as string
-      );
+      LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_X_LICENSE_KEY as string);
       return <Story />;
     },
   ],
@@ -93,19 +91,19 @@ export const ErrorFallback: Story = {
     rows,
     label: "Intact Hi-C Loops",
     divHeight: {
-      height: '350px'
+      height: "350px",
     },
     error: true,
-  }
-}
+  },
+};
 
 export const FlexWrapper: Story = {
   args: {
     columns,
     rows,
     label: "This table fills container",
-  }
-}
+  },
+};
 
 export const FixedHeightWrapper: Story = {
   args: {
@@ -113,34 +111,10 @@ export const FixedHeightWrapper: Story = {
     rows,
     label: "This table has a fixed 350px height",
     divHeight: {
-      height: '350px'
-    }
-  }
-}
-
-function SimplePopper() {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(anchorEl ? null : event.currentTarget);
-  };
-
-  const open = Boolean(anchorEl);
-  const id = open ? 'simple-popper' : undefined;
-
-  return (
-    <div>
-      <button aria-describedby={id} type="button" onClick={handleClick}>
-        Toggle Popper
-      </button>
-      <Popper id={id} open={open} anchorEl={anchorEl}>
-        <Box sx={{ border: 1, p: 1, bgcolor: 'background.paper' }}>
-          The content of the Popper.
-        </Box>
-      </Popper>
-    </div>
-  );
-}
+      height: "350px",
+    },
+  },
+};
 
 export const UseToolbarSlot: Story = {
   args: {
@@ -148,18 +122,62 @@ export const UseToolbarSlot: Story = {
     rows,
     label: "This table is using the extra toolbar slot",
     divHeight: {
-      height: '350px'
+      height: "350px",
     },
-    toolbarSlot: <SimplePopper />
-  }
-}
+  },
+  render: (args) => {
+    const [count, setCount] = React.useState(0);
+    const [anchorEl, setAnchorEl] = React.useState<PopperProps["anchorEl"]>(null);
+
+    const handleIncrementAge = React.useCallback(() => {
+      setCount((prev) => prev + 1);
+    }, []);
+
+    const handleTogglePopper = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      if (anchorEl) {
+        setAnchorEl(null);
+      } else {
+        const rect = e.currentTarget.getBoundingClientRect() //must capture here before setting state with it!
+        setAnchorEl({ getBoundingClientRect: () => rect });
+      }
+    };
+
+    const modifiedRows = React.useMemo(() => {
+      return rows.map((x) => {
+        return { ...x, age: x.age === null ? null : x.age + count };
+      });
+    }, [rows, count]);
+
+    return (
+      <Stack gap={2}>
+        <Typography>Age increased by {count}</Typography>
+        <Table
+          {...args}
+          rows={modifiedRows}
+          toolbarSlot={
+            <Button variant="contained" size="small" onClick={handleTogglePopper}>
+              Toggle Popper
+            </Button>
+          }
+        />
+        <Popper open={Boolean(anchorEl)} anchorEl={anchorEl}>
+          <Box sx={{ border: 1, p: 1, bgcolor: "background.paper" }}>
+            <Button size="small" onClick={handleIncrementAge}>
+              Increment Age
+            </Button>
+          </Box>
+        </Popper>
+      </Stack>
+    );
+  },
+};
 
 export const LabelTooltip: Story = {
   args: {
     columns,
     rows,
     label: "Table Title",
-    labelTooltip: "This is a tooltip"
+    labelTooltip: "This is a tooltip",
   },
 };
 

--- a/packages/ui-components/src/components/Table/Table.stories.tsx
+++ b/packages/ui-components/src/components/Table/Table.stories.tsx
@@ -4,7 +4,7 @@ import { Table } from "../..";
 import { LicenseInfo } from "@mui/x-license";
 import { GridColDef } from "@mui/x-data-grid-pro";
 import { Box, Button, Popper, PopperProps, Stack, Tooltip, Typography } from "@mui/material";
-import { InfoOutline, QuestionMark } from "@mui/icons-material";
+import { QuestionMark } from "@mui/icons-material";
 
 const meta = {
   title: "ui-components/Table",

--- a/packages/ui-components/src/components/Table/Table.stories.tsx
+++ b/packages/ui-components/src/components/Table/Table.stories.tsx
@@ -2,7 +2,8 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { Table } from "../..";
 import { LicenseInfo } from "@mui/x-license";
 import { GridColDef } from "@mui/x-data-grid-pro";
-import { Button } from "@mui/material";
+import { Button, Tooltip } from "@mui/material";
+import { InfoOutline, QuestionMark } from "@mui/icons-material";
 
 const meta = {
   title: "ui-components/Table",
@@ -127,3 +128,25 @@ export const OverrideToolbar: Story = {
     toolbarSlot: <Button variant="outlined" sx={{textTransform: 'none'}} size="small">Extra Button</Button>
   }
 }
+
+export const LabelTooltip: Story = {
+  args: {
+    columns,
+    rows,
+    label: "Table Title",
+    labelTooltip: "This is a tooltip"
+  },
+};
+
+export const LabelTooltipCustomElement: Story = {
+  args: {
+    columns,
+    rows,
+    label: "Table Title",
+    labelTooltip: (
+      <Tooltip title={"tooltip contents"}>
+        <QuestionMark fontSize="inherit" />
+      </Tooltip>
+    ),
+  },
+};

--- a/packages/ui-components/src/components/Table/Table.stories.tsx
+++ b/packages/ui-components/src/components/Table/Table.stories.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react'
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Table } from "../..";
 import { LicenseInfo } from "@mui/x-license";
 import { GridColDef } from "@mui/x-data-grid-pro";
-import { Button, Tooltip } from "@mui/material";
+import { Box, Button, Popper, Tooltip } from "@mui/material";
 import { InfoOutline, QuestionMark } from "@mui/icons-material";
 
 const meta = {
@@ -117,7 +118,31 @@ export const FixedHeightWrapper: Story = {
   }
 }
 
-export const OverrideToolbar: Story = {
+function SimplePopper() {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : event.currentTarget);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popper' : undefined;
+
+  return (
+    <div>
+      <button aria-describedby={id} type="button" onClick={handleClick}>
+        Toggle Popper
+      </button>
+      <Popper id={id} open={open} anchorEl={anchorEl}>
+        <Box sx={{ border: 1, p: 1, bgcolor: 'background.paper' }}>
+          The content of the Popper.
+        </Box>
+      </Popper>
+    </div>
+  );
+}
+
+export const UseToolbarSlot: Story = {
   args: {
     columns,
     rows,
@@ -125,7 +150,7 @@ export const OverrideToolbar: Story = {
     divHeight: {
       height: '350px'
     },
-    toolbarSlot: <Button variant="outlined" sx={{textTransform: 'none'}} size="small">Extra Button</Button>
+    toolbarSlot: <SimplePopper />
   }
 }
 

--- a/packages/ui-components/src/components/Table/Table.tsx
+++ b/packages/ui-components/src/components/Table/Table.tsx
@@ -26,10 +26,14 @@ const Table = (props: TableProps) => {
     divHeight = {},
     sx = {},
     error = false,
-    toolbarSlot,
     slots = {},
+    label,
+    labelTooltip,
+    toolbarSlot,
     ...restDataGridProps
   } = props;
+
+  const toolbarProps = { label, labelTooltip, toolbarSlot };
 
   //Assign default ID if no ID is provided in the row data
   const rowsWithIds = useMemo(
@@ -76,7 +80,7 @@ const Table = (props: TableProps) => {
   }
 
   if (error) {
-    return <TableFallback message={`Error fetching ${restDataGridProps.label}`} variant="error" />
+    return <TableFallback message={`Error fetching ${label}`} variant="error" />
   }
 
   return (
@@ -110,7 +114,7 @@ const Table = (props: TableProps) => {
           ...sx,
         }}
         slots={{
-          toolbar: () => <CustomToolbar label={restDataGridProps.label} extraComponentSlot={toolbarSlot} />,
+          toolbar: () => <CustomToolbar {...toolbarProps} />,
           ...slots
         }}
         {...restDataGridProps}

--- a/packages/ui-components/src/components/Table/Table.tsx
+++ b/packages/ui-components/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ const Table = (props: TableProps) => {
   /**
    * Provide defaults
    * @todo obey the defaults specified in the theme.
-   * Ex: Overriding pageSizeOptions like this overrides the defaults specified in the theme
+   * Ex: Overriding density like this overrides the defaults specified in the theme
    */
   const {
     pagination = true,

--- a/packages/ui-components/src/components/Table/types.ts
+++ b/packages/ui-components/src/components/Table/types.ts
@@ -61,11 +61,15 @@ export interface TableProps extends DataGridProProps {
    * @default false
    */
   error?: boolean
-
   /**
    * Slot for extra component to be rendered within the toolbar, to the left of the filters
    */
   toolbarSlot?: ReactNode
+  /**
+   * If anything besides an element, renders tooltip icon to the right of the table label with specified string as tooltip contents.
+   * If an element, renders the element to the right of the table label.
+   */
+  labelTooltip?: ReactNode
 }
 
 export type TableToolbarProps = {


### PR DESCRIPTION
Fix #12 - Clear input on assembly switch
Also, on enter press, modify the state to select the option instead of just calling the onSubmit. Previously this checked to see if results was length 1, then called onSubmit with this option. This does not cover cases where the intended gene is a prefix of at least one other (ex: SP1 and SP100). Now this checks for case-insensitive exact match, selects the option, and then calls onSubmit
Fix #10 - Add `labelTooltip` prop
Adds example for using virtual element anchor on a popper in Table stories. See #9 