### PR TITLE
Fix #20

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weng-lab/ui-components",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "React MUI components for the Weng/Moore Labs suite of genomics web resources",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/ui-components/src/components/Table/CustomToolbar.tsx
+++ b/packages/ui-components/src/components/Table/CustomToolbar.tsx
@@ -12,6 +12,8 @@ import {
   QuickFilterClear,
   QuickFilterTrigger,
   DataGridProProps,
+  GridToolbarProps,
+  ToolbarPropsOverrides,
 } from "@mui/x-data-grid-pro";
 import Tooltip from "@mui/material/Tooltip";
 import Menu from "@mui/material/Menu";
@@ -62,9 +64,9 @@ type CustomToolbarProps = {
   label: DataGridProProps["label"];
   labelTooltip: TableProps["labelTooltip"];
   toolbarSlot?: React.ReactNode;
-};
+ } & GridToolbarProps & ToolbarPropsOverrides;
 
-export function CustomToolbar({ label, labelTooltip, toolbarSlot }: CustomToolbarProps) {
+export function CustomToolbar({ label, labelTooltip, toolbarSlot, ...restToolbarProps }: CustomToolbarProps) {
   const [exportMenuOpen, setExportMenuOpen] = React.useState(false);
   const exportMenuTriggerRef = React.useRef<HTMLButtonElement>(null);
 
@@ -106,9 +108,7 @@ export function CustomToolbar({ label, labelTooltip, toolbarSlot }: CustomToolba
           )}
         />
       </Tooltip>
-
       <Divider orientation="vertical" variant="middle" flexItem sx={{ mx: 0.5 }} />
-
       <Tooltip title="Export">
         <ToolbarButton
           ref={exportMenuTriggerRef}
@@ -135,10 +135,10 @@ export function CustomToolbar({ label, labelTooltip, toolbarSlot }: CustomToolba
           },
         }}
       >
-        <ExportPrint render={<MenuItem />} onClick={() => setExportMenuOpen(false)}>
+        <ExportPrint options={{...restToolbarProps.printOptions}} render={<MenuItem />} onClick={() => setExportMenuOpen(false)}>
           Print
         </ExportPrint>
-        <ExportCsv render={<MenuItem />} onClick={() => setExportMenuOpen(false)}>
+        <ExportCsv options={{fileName: label, ...restToolbarProps.csvOptions}} render={<MenuItem />} onClick={() => setExportMenuOpen(false)}>
           Download as CSV
         </ExportCsv>
       </Menu>

--- a/packages/ui-components/src/components/Table/Table.stories.tsx
+++ b/packages/ui-components/src/components/Table/Table.stories.tsx
@@ -193,3 +193,12 @@ export const LabelTooltipCustomElement: Story = {
     ),
   },
 };
+
+export const OverrideToolbarProps: Story = {
+  args: {
+    columns,
+    rows,
+    label: "Table Title",
+    slotProps: {toolbar: {csvOptions: {fileName: 'overrideFilename'}}}
+  },
+};

--- a/packages/ui-components/src/components/Table/Table.tsx
+++ b/packages/ui-components/src/components/Table/Table.tsx
@@ -1,6 +1,8 @@
 import {
   DataGridPro,
   GridAutosizeOptions,
+  GridToolbarProps,
+  ToolbarPropsOverrides,
   useGridApiRef,
 } from "@mui/x-data-grid-pro";
 import { useMemo, useEffect, useCallback } from "react";
@@ -33,7 +35,7 @@ const Table = (props: TableProps) => {
     ...restDataGridProps
   } = props;
 
-  const toolbarProps = { label, labelTooltip, toolbarSlot };
+  const customToolbarProps = { label, labelTooltip, toolbarSlot };
 
   //Assign default ID if no ID is provided in the row data
   const rowsWithIds = useMemo(
@@ -114,7 +116,7 @@ const Table = (props: TableProps) => {
           ...sx,
         }}
         slots={{
-          toolbar: () => <CustomToolbar {...toolbarProps} />,
+          toolbar: (props: GridToolbarProps & ToolbarPropsOverrides) => <CustomToolbar {...props} {...customToolbarProps} />,
           ...slots
         }}
         {...restDataGridProps}


### PR DESCRIPTION
Fix #20 

Passes `slotProps.toolbar` to CustomToolbar. Notably, `CustomToolbar` is only currently using `printOptions` and `csvOptions`. There is no documentation on the shape of slotProps.toolbar so it's likely that the CustomToolbar is not properly fully using the passed slotProps. May need to revisit in the future