### PR TITLE
ui-components 3.1.4 - Remove width/height 100% from DetailsTabs

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weng-lab/ui-components",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "React MUI components for the Weng/Moore Labs suite of genomics web resources",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/ui-components/src/components/DetailsTabs/DetailsTabs.tsx
+++ b/packages/ui-components/src/components/DetailsTabs/DetailsTabs.tsx
@@ -92,8 +92,6 @@ export const DetailsTabs = ({
             },
           },
           contain: "layout",
-          width: "100%",
-          height: "100%",
           ...sx,
         }}
       >


### PR DESCRIPTION
Let consumer fully own sizing. There was a small height bug that necessitated setting `sx.height: "intitial"` in SCREEN, and there we are already overriding width so just remove both.