### PR TITLE
Heatmap PR suggestions

### DIFF
--- a/packages/visualization/src/components/Heatmap/Heatmap.tsx
+++ b/packages/visualization/src/components/Heatmap/Heatmap.tsx
@@ -5,6 +5,7 @@ import { downloadAsSVG, downloadSVGAsPNG } from "../../utility";
 import { ResponsiveContainer, useResponsiveParentSize } from "../../responsive";
 import { AxisLeft, AxisBottom } from "@visx/axis";
 import HeatmapCells from "./HeatmapCells";
+import { heatmapCellStyles } from "./HeatmapCell";
 import HeatmapLegend, { getHeatmapLegendWidth } from "./HeatmapLegend";
 
 const LEGEND_GAP = 16;
@@ -14,7 +15,9 @@ const AXIS_LABEL_GAP = 12;
 const getBins = (d: ColumnDatum) => d.rows;
 
 function maxOf<Datum>(data: Datum[], value: (d: Datum) => number): number {
-  return Math.max(...data.map(value));
+  // reduce rather than Math.max(...spread): returns 0 (not -Infinity) for an empty array,
+  // and has no argument-count ceiling.
+  return data.reduce((max, datum) => Math.max(max, value(datum)), 0);
 }
 
 const Heatmap = ({
@@ -41,7 +44,7 @@ const Heatmap = ({
   const svgRef = useRef<SVGSVGElement | null>(null);
 
   const allColNames = useMemo(() => data.map((d) => d.columnName), [data]);
-  const allRowNames = useMemo(() => data[0].rows.map((r) => r.rowName), [data]);
+  const allRowNames = useMemo(() => data[0]?.rows.map((r) => r.rowName) ?? [], [data]);
   const maxValue = useMemo(() => maxOf(data, (d) => maxOf(getBins(d), (r) => r.count)), [data]);
   const numRows = useMemo(() => maxOf(data, (d) => getBins(d).length), [data]);
 
@@ -54,6 +57,16 @@ const Heatmap = ({
   // proportionally less (sin of a 45deg rotation), and horizontal labels only need a single line.
   const rotatedColNameSpace = maxColNameLength * 8;
   const colLabelHeight = xLabelOrientation === "horizontal" ? 12 : xLabelOrientation === "vertical" ? rotatedColNameSpace : rotatedColNameSpace * Math.SQRT1_2;
+
+  // Consumers nearly always pass `colors` as an inline array literal, so its identity changes on
+  // every render of theirs. That alone rebuilds the color scale and, through it, every cell in the
+  // grid. Keying on the contents means the array is only replaced when the colors really change.
+  // (A NUL separator cannot appear in a CSS color, so the join is unambiguous.)
+  const colorsKey = colors.join("\u0000");
+  const stableColors = useMemo(
+    () => colorsKey.split("\u0000") as [string, string, ...string[]],
+    [colorsKey]
+  );
 
   const legendWidth = useMemo(() => getHeatmapLegendWidth(0, maxValue), [maxValue]);
   const defaultRight = showLegend ? legendWidth + LEGEND_GAP : 10;
@@ -85,7 +98,7 @@ const Heatmap = ({
   );
 
   const xTickValues = useMemo(() => data.map((_, i) => i + 0.5), [data]);
-  const yTickValues = useMemo(() => data[0].rows.map((_, i) => i + 0.5), [data]);
+  const yTickValues = useMemo(() => data[0]?.rows.map((_, i) => i + 0.5) ?? [], [data]);
 
   useImperativeHandle(ref, () => ({
     downloadSVG: () => {
@@ -94,19 +107,22 @@ const Heatmap = ({
     downloadPNG: () => {
       if (svgRef.current) downloadSVGAsPNG(svgRef.current, downloadFileName ?? "heatmap.png");
     },
-  }));
+  }), [downloadFileName]);
 
   return (
     <ResponsiveContainer parentRef={parentRef} containerStyle={containerStyle}>
-      {/* Prevent undefined parent size from causing creation of elements with negative dimensions */}
-      {!parentWidth || !parentHeight ? null : (
+      {/* Prevent an undefined parent size, or empty data, from producing elements with negative
+          or non-finite dimensions */}
+      {!parentWidth || !parentHeight || data.length === 0 || numRows === 0 ? null : (
         <svg width={parentWidth} height={parentHeight} ref={svgRef}>
+          {/* Inside the <svg> so cell hover styling survives the SVG/PNG download serialization */}
+          <style>{heatmapCellStyles}</style>
           <g transform={`translate(${marg.left},${marg.top})`}>
             <HeatmapCells
               data={data}
               xScale={xScale}
               yScale={yScale}
-              colors={colors}
+              colors={stableColors}
               maxValue={maxValue}
               gap={gap}
               isRect={isRect}
@@ -164,7 +180,7 @@ const Heatmap = ({
             {showLegend && (
               <g transform={`translate(${xMax + LEGEND_GAP}, ${binHeight})`}>
                 <HeatmapLegend
-                  colors={colors}
+                  colors={stableColors}
                   minValue={0}
                   maxValue={maxValue}
                   height={yMax}

--- a/packages/visualization/src/components/Heatmap/HeatmapCell.tsx
+++ b/packages/visualization/src/components/Heatmap/HeatmapCell.tsx
@@ -1,12 +1,29 @@
-import { memo, useState, ReactElement, MouseEvent } from "react";
-import { Portal, TooltipWithBounds, useTooltip } from "@visx/tooltip";
+import { memo, MouseEvent } from "react";
 import { motion } from "framer-motion";
 import { getAnimationProps } from "../../utility";
 import type { AnimationType } from "../../utility";
 import type { AnyBin } from "./HeatmapCells";
+import type { PlotTooltipRef } from "../../tooltip";
 
-const CELL_STYLE = { cursor: "pointer" };
-const WRAPPER_STYLE = { cursor: "pointer", transition: "stroke-width 0.2s" };
+/** Class on the <g> wrapping each cell. The hover rule keys off this. */
+export const CELL_CLASS = "visx-heatmap-cell";
+/** Class on the <rect>/<circle> inside each cell. */
+export const CELL_SHAPE_CLASS = "visx-heatmap-cell-shape";
+
+/**
+ * Hover styling is plain CSS rather than React state: `:hover` costs no render at all, while
+ * tracking hover in state re-renders on every cell the pointer crosses. Rendered once per chart
+ * by Heatmap, inside the <svg> so it survives the SVG/PNG download serialization.
+ *
+ * The stroke is always painted in the cell's own fill color, so hovering only has to give it a
+ * width. `strokeWidth={0}` below is a presentation attribute, which loses to any CSS rule - so
+ * the hover rule wins without needing !important.
+ */
+export const heatmapCellStyles = `
+.${CELL_CLASS} { cursor: pointer; }
+.${CELL_SHAPE_CLASS} { transition: stroke-width 0.2s; }
+.${CELL_CLASS}:hover .${CELL_SHAPE_CLASS} { stroke-width: 2; }
+`;
 
 export interface HeatmapCellProps {
   bin: AnyBin;
@@ -16,81 +33,94 @@ export interface HeatmapCellProps {
   fillOpacity: number;
   colIndex: number;
   animationType?: AnimationType;
-  tooltipBody?: (bin: AnyBin) => ReactElement;
+  /** Stable for the life of the plot, so it never invalidates this cell's memoization. */
+  tooltipRef: PlotTooltipRef<AnyBin>;
   onClick?: (bin: AnyBin) => void;
 }
 
-// Tooltip/hover state is local to each cell (rather than shared across the whole grid in the
-// parent) so hovering one cell only re-renders that cell, not every cell in the heatmap.
+/**
+ * visx rebuilds every bin object inside its own render, so `bin` always arrives with a fresh
+ * identity and memo's default shallow compare can never bail out. Comparing the bin's fields
+ * instead lets untouched cells skip re-rendering, which is what makes selection changes cheap:
+ * only the cells whose appearance actually changed re-render, rather than the whole grid.
+ *
+ * `bin.bin` and `bin.datum` are the caller's own row/column data, which do keep identity, so a
+ * reference check on those covers data and metadata changes.
+ */
+const binsEqual = (a: AnyBin, b: AnyBin): boolean => {
+  if (
+    a.row !== b.row ||
+    a.column !== b.column ||
+    a.count !== b.count ||
+    a.gap !== b.gap ||
+    a.color !== b.color ||
+    a.opacity !== b.opacity ||
+    a.bin !== b.bin ||
+    a.datum !== b.datum
+  ) {
+    return false;
+  }
+  // Rect and circle cells carry different geometry fields
+  if ("x" in a) {
+    return "x" in b && a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+  }
+  return "cy" in b && a.cy === b.cy && a.r === b.r && a.radius === b.radius;
+};
+
+/**
+ * Must compare every prop in HeatmapCellProps - one left out here would silently stop updating.
+ */
+const cellPropsEqual = (prev: HeatmapCellProps, next: HeatmapCellProps): boolean =>
+  prev.fill === next.fill &&
+  prev.fillOpacity === next.fillOpacity &&
+  prev.isRect === next.isRect &&
+  prev.binWidth === next.binWidth &&
+  prev.colIndex === next.colIndex &&
+  prev.animationType === next.animationType &&
+  prev.tooltipRef === next.tooltipRef &&
+  prev.onClick === next.onClick &&
+  binsEqual(prev.bin, next.bin);
+
 const HeatmapCell = memo(function HeatmapCell({
   bin, isRect, binWidth, fill, fillOpacity, colIndex,
-  animationType, tooltipBody, onClick,
+  animationType, tooltipRef, onClick,
 }: HeatmapCellProps) {
-  const [isHovered, setIsHovered] = useState(false);
-  const { tooltipData, tooltipLeft, tooltipTop, tooltipOpen, showTooltip, hideTooltip } = useTooltip<ReactElement>();
-
   const isRectCell = isRect && "width" in bin && "height" in bin && "x" in bin && "y" in bin;
   const isCircleCell = !isRect && "cy" in bin && "r" in bin;
 
-  const sharedProps = {
-    fill,
-    fillOpacity,
-    stroke: isHovered ? fill : "none",
-    strokeWidth: isHovered ? 2 : 0,
-    style: CELL_STYLE,
-  };
+  const sharedProps = { fill, fillOpacity, stroke: fill, strokeWidth: 0 };
 
   const Wrapper = animationType ? motion.g : "g";
   const animProps = getAnimationProps(animationType as AnimationType, colIndex);
 
   return (
-    <>
-      <Wrapper
-        {...animProps}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => {
-          setIsHovered(false);
-          hideTooltip();
-        }}
-        onMouseMove={(event: MouseEvent<SVGElement>) => {
-          if (!tooltipBody) return;
-          showTooltip({
-            tooltipLeft: event.pageX + 10,
-            tooltipTop: event.pageY + 10,
-            tooltipData: tooltipBody(bin),
-          });
-        }}
-        onClick={() => onClick?.(bin)}
-        style={WRAPPER_STYLE}
-      >
-        {isRectCell ? (
-          <rect
-            className="visx-heatmap-rect"
-            width={bin.width}
-            height={bin.height}
-            x={bin.x}
-            y={bin.y}
-            {...sharedProps}
-          />
-        ) : isCircleCell ? (
-          <circle
-            className="visx-heatmap-circle"
-            cx={bin.column * binWidth + binWidth / 2}
-            cy={bin.cy}
-            r={bin.r}
-            {...sharedProps}
-          />
-        ) : null}
-      </Wrapper>
-      {tooltipBody && tooltipOpen && tooltipData && (
-        <Portal>
-          <TooltipWithBounds left={tooltipLeft} top={tooltipTop}>
-            {tooltipData}
-          </TooltipWithBounds>
-        </Portal>
-      )}
-    </>
+    <Wrapper
+      {...animProps}
+      className={CELL_CLASS}
+      onMouseMove={(event: MouseEvent<SVGElement>) => tooltipRef.current?.show(bin, event)}
+      onMouseLeave={() => tooltipRef.current?.hide()}
+      onClick={() => onClick?.(bin)}
+    >
+      {isRectCell ? (
+        <rect
+          className={`visx-heatmap-rect ${CELL_SHAPE_CLASS}`}
+          width={bin.width}
+          height={bin.height}
+          x={bin.x}
+          y={bin.y}
+          {...sharedProps}
+        />
+      ) : isCircleCell ? (
+        <circle
+          className={`visx-heatmap-circle ${CELL_SHAPE_CLASS}`}
+          cx={bin.column * binWidth + binWidth / 2}
+          cy={bin.cy}
+          r={bin.r}
+          {...sharedProps}
+        />
+      ) : null}
+    </Wrapper>
   );
-});
+}, cellPropsEqual);
 
 export default HeatmapCell;

--- a/packages/visualization/src/components/Heatmap/HeatmapCell.tsx
+++ b/packages/visualization/src/components/Heatmap/HeatmapCell.tsx
@@ -18,10 +18,14 @@ export const CELL_SHAPE_CLASS = "visx-heatmap-cell-shape";
  * The stroke is always painted in the cell's own fill color, so hovering only has to give it a
  * width. `strokeWidth={0}` below is a presentation attribute, which loses to any CSS rule - so
  * the hover rule wins without needing !important.
+ *
+ * `pointer-events: all` because cells with a null count render with fill="none", and SVG's
+ * default (visiblePainted) only treats painted area as a hit target - without this the pointer
+ * falls through such a cell to the <svg> and it can never show its "no data" tooltip.
  */
 export const heatmapCellStyles = `
 .${CELL_CLASS} { cursor: pointer; }
-.${CELL_SHAPE_CLASS} { transition: stroke-width 0.2s; }
+.${CELL_SHAPE_CLASS} { transition: stroke-width 0.2s; pointer-events: all; }
 .${CELL_CLASS}:hover .${CELL_SHAPE_CLASS} { stroke-width: 2; }
 `;
 

--- a/packages/visualization/src/components/Heatmap/HeatmapCells.tsx
+++ b/packages/visualization/src/components/Heatmap/HeatmapCells.tsx
@@ -1,9 +1,11 @@
 import { HeatmapRect, HeatmapCircle, RectCell, CircleCell } from "@visx/heatmap";
 import { scaleLinear } from "@visx/scale";
-import { useMemo, memo, ReactElement } from "react";
+import { useMemo, useRef, memo, ReactElement } from "react";
 import type { AnimationType } from "../../utility";
 import type { ColumnDatum, RowDatum, HeatmapCellId } from "./types";
 import HeatmapCell from "./HeatmapCell";
+import { PlotTooltip, type PlotTooltipHandle } from "../../tooltip";
+import { useStableCallback } from "../../hooks";
 
 export type AnyBin = RectCell<ColumnDatum, RowDatum> | CircleCell<ColumnDatum, RowDatum>;
 
@@ -51,41 +53,52 @@ const HeatmapCells = memo(function HeatmapCells({
     [selectedCells]
   );
 
+  // The tooltip is a sibling of the grid and owns its own state, so moving the pointer around
+  // never re-renders a cell. Cells reach it through this ref, which never changes identity.
+  const tooltipRef = useRef<PlotTooltipHandle<AnyBin>>(null);
+
+  // Consumers commonly pass an inline arrow for onClick. Cells are memoized on prop identity,
+  // so forwarding that directly would invalidate every cell on each render of the consumer.
+  const handleClick = useStableCallback(onClick);
+
   const HeatmapComponent = isRect ? HeatmapRect : HeatmapCircle;
 
   return (
-    <HeatmapComponent
-      data={data}
-      xScale={xScale}
-      yScale={yScale}
-      colorScale={colorScale}
-      opacityScale={opacityScale}
-      bins={getBins}
-      gap={gap}
-      {...(isRect ? { binWidth, binHeight } : { radius })}
-    >
-      {(heatmap) =>
-        heatmap.map((heatmapBins, colIndex) =>
-          heatmapBins.map((bin) => {
-            const isDeselected = !!selectedKeys && !selectedKeys.has(cellKey(bin));
-            return (
-              <HeatmapCell
-                key={`heatmap-cell-${bin.row}-${bin.column}`}
-                bin={bin}
-                isRect={isRect}
-                binWidth={binWidth}
-                fill={isDeselected ? deselectedColor : bin.color ?? deselectedColor}
-                fillOpacity={isDeselected ? DESELECTED_OPACITY : bin.opacity ?? 1}
-                colIndex={colIndex}
-                animationType={animationType}
-                tooltipBody={tooltipBody}
-                onClick={onClick}
-              />
-            );
-          })
-        )
-      }
-    </HeatmapComponent>
+    <>
+      <HeatmapComponent
+        data={data}
+        xScale={xScale}
+        yScale={yScale}
+        colorScale={colorScale}
+        opacityScale={opacityScale}
+        bins={getBins}
+        gap={gap}
+        {...(isRect ? { binWidth, binHeight } : { radius })}
+      >
+        {(heatmap) =>
+          heatmap.map((heatmapBins, colIndex) =>
+            heatmapBins.map((bin) => {
+              const isDeselected = !!selectedKeys && !selectedKeys.has(cellKey(bin));
+              return (
+                <HeatmapCell
+                  key={`heatmap-cell-${bin.row}-${bin.column}`}
+                  bin={bin}
+                  isRect={isRect}
+                  binWidth={binWidth}
+                  fill={isDeselected ? deselectedColor : bin.color ?? deselectedColor}
+                  fillOpacity={isDeselected ? DESELECTED_OPACITY : bin.opacity ?? 1}
+                  colIndex={colIndex}
+                  animationType={animationType}
+                  tooltipRef={tooltipRef}
+                  onClick={handleClick}
+                />
+              );
+            })
+          )
+        }
+      </HeatmapComponent>
+      {tooltipBody && <PlotTooltip ref={tooltipRef}>{tooltipBody}</PlotTooltip>}
+    </>
   );
 });
 

--- a/packages/visualization/src/hooks/index.ts
+++ b/packages/visualization/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useStableCallback } from './useStableCallback';

--- a/packages/visualization/src/hooks/useStableCallback.ts
+++ b/packages/visualization/src/hooks/useStableCallback.ts
@@ -1,0 +1,28 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+/**
+ * Wraps a callback in a stable identity that always forwards to the most recent version.
+ *
+ * Plots pass consumer callbacks (onClick and friends) down to memoized marks. Consumers of this
+ * package will not necessarily have the React Compiler enabled, so those props commonly arrive
+ * as a fresh inline arrow on every render - handing one straight to thousands of memoized marks
+ * invalidates all of them. Wrapping it here gives the marks a prop that never changes identity
+ * while still calling the latest callback.
+ *
+ * The returned callback must only be invoked from event handlers or effects, never during
+ * render: the ref is updated after commit, so during render it still holds the previous value.
+ */
+export function useStableCallback<Args extends unknown[], R>(
+  callback: ((...args: Args) => R) | undefined
+): (...args: Args) => R | undefined {
+  const callbackRef = useRef(callback);
+
+  // Layout effect rather than assigning during render, which is unsafe under concurrent
+  // rendering (a render can be thrown away). This runs before the browser can dispatch the
+  // next event, so the ref is always current by the time the returned callback can fire.
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return useCallback((...args: Args) => callbackRef.current?.(...args), []);
+}

--- a/packages/visualization/src/index.ts
+++ b/packages/visualization/src/index.ts
@@ -31,3 +31,8 @@ export type { HistogramProps, HistogramBin } from './components/Histogram';
 
 export { useResponsiveParentSize, ResponsiveContainer } from './responsive';
 export type { ManualSizeProps, UseResponsiveParentSizeResult, ResponsiveContainerProps } from './responsive';
+
+export { useStableCallback } from './hooks';
+
+export { PlotTooltip } from './tooltip';
+export type { PlotTooltipHandle, PlotTooltipRef, PlotTooltipProps } from './tooltip';

--- a/packages/visualization/src/tooltip/PlotTooltip.tsx
+++ b/packages/visualization/src/tooltip/PlotTooltip.tsx
@@ -1,0 +1,76 @@
+import { memo, useImperativeHandle, useState, MouseEvent, ReactNode, Ref, RefObject } from "react";
+import { Portal, TooltipWithBounds } from "@visx/tooltip";
+
+/** Offset from the pointer, so the tooltip never sits directly under the cursor. */
+const POINTER_OFFSET = 10;
+
+export interface PlotTooltipHandle<T> {
+  /** Show the tooltip for `data`, positioned from the pointer event that triggered it. */
+  show: (data: T, event: MouseEvent) => void;
+  hide: () => void;
+}
+
+/**
+ * The ref as marks receive it. Spelling out `RefObject<PlotTooltipHandle<T> | null>` in every
+ * mark component is noisy and easy to get wrong (the `| null` is required - useRef(null) yields
+ * a nullable current until PlotTooltip mounts).
+ */
+export type PlotTooltipRef<T> = RefObject<PlotTooltipHandle<T> | null>;
+
+export interface PlotTooltipProps<T> {
+  ref: Ref<PlotTooltipHandle<T>>;
+  /** Renders the tooltip contents. Called here, not by the marks, so marks never depend on it. */
+  children: (data: T) => ReactNode;
+}
+
+interface PlotTooltipState<T> {
+  open: boolean;
+  data?: T;
+  left: number;
+  top: number;
+}
+
+/**
+ * A single tooltip for a plot with many interactive marks (cells, bars, points, nodes).
+ *
+ * Render it as a *sibling* of the marks - never as an ancestor - and drive it through the ref:
+ *
+ *   const tooltipRef = useRef<PlotTooltipHandle<Bin>>(null);
+ *   ...
+ *   <Marks tooltipRef={tooltipRef} />
+ *   <PlotTooltip ref={tooltipRef}>{(bin) => <div>{bin.count}</div>}</PlotTooltip>
+ *
+ * with each mark doing `onMouseMove={(e) => tooltipRef.current?.show(bin, e)}`.
+ *
+ * Why this shape:
+ * - Tooltip state lives below the marks in the tree rather than above them, so showing, moving
+ *   and hiding the tooltip re-renders only this component. Holding the state in the plot itself
+ *   re-renders every mark on every mousemove; giving each mark its own useTooltip instead costs
+ *   one state hook and one portal per mark.
+ * - Marks receive only `tooltipRef`, which is stable for the lifetime of the plot. They never
+ *   receive the tooltip body renderer, so an unstable one from a consumer cannot invalidate them.
+ * - `show` takes the datum rather than rendered output, so nothing is rendered for marks the
+ *   pointer never reaches.
+ */
+function PlotTooltip<T>({ ref, children }: PlotTooltipProps<T>) {
+  const [state, setState] = useState<PlotTooltipState<T>>({ open: false, left: 0, top: 0 });
+
+  useImperativeHandle(ref, () => ({
+    show: (data, event) =>
+      setState({ open: true, data, left: event.pageX + POINTER_OFFSET, top: event.pageY + POINTER_OFFSET }),
+    hide: () => setState((current) => (current.open ? { ...current, open: false } : current)),
+  }), []);
+
+  if (!state.open || state.data === undefined) return null;
+
+  return (
+    <Portal>
+      <TooltipWithBounds left={state.left} top={state.top}>
+        {children(state.data)}
+      </TooltipWithBounds>
+    </Portal>
+  );
+}
+
+// memo() doesn't preserve generic type parameters, so cast back to the generic signature
+export default memo(PlotTooltip) as typeof PlotTooltip;

--- a/packages/visualization/src/tooltip/index.ts
+++ b/packages/visualization/src/tooltip/index.ts
@@ -1,0 +1,2 @@
+export { default as PlotTooltip } from './PlotTooltip';
+export type { PlotTooltipHandle, PlotTooltipRef, PlotTooltipProps } from './PlotTooltip';


### PR DESCRIPTION
thanks claude

# Heatmap: hover, tooltip, and memoization follow-ups

Builds on `heatmpaImprovemtns`. That PR correctly identified the real problem — hovering a cell
re-rendered the entire grid — and per-cell state does fix it. This takes a different route to the
same goal that costs less per cell, and picks up a few things found along the way.

Merged with the `allow null values` commit; the two conflicts (`maxOf`, and the cell render in
`HeatmapCells`) are resolved to keep both sides' intent — see §6.

8 files, +293 / -115.

---

## Summary

| | before (PR branch) | after |
|---|---|---|
| hover state | `useState` per cell | CSS `:hover`, no React state |
| tooltip state | `useTooltip` + `Portal` per cell | one instance per chart |
| `tooltipBody` calls per grid render | one per cell, discarded | 0 (called on hover only) |
| heap @ 4,900 cells | 14.59 MB | 10.92 MB |
| script per pointer move | 0.387 ms | 0.13 ms |
| script per cell-to-cell hop | 0.654 ms | 0.22 ms |

The last two no longer scale with cell count (0.29 ms/move at 400 cells vs 0.13 ms at 4,900),
which is the actual evidence that no cells re-render on hover.

---

## 1. Hover is now CSS

The stroke is always painted in the cell's own fill color at `strokeWidth={0}`; hover just gives
it a width.

```css
.visx-heatmap-cell { cursor: pointer; }
.visx-heatmap-cell-shape { transition: stroke-width 0.2s; pointer-events: all; }
.visx-heatmap-cell:hover .visx-heatmap-cell-shape { stroke-width: 2; }
```

`strokeWidth={0}` is a presentation attribute, which loses to any CSS rule, so this wins without
`!important`. (`pointer-events` is there for null-count cells — §6.)

**Why a `<style>` inside the `<svg>` rather than a `.css` file:** the package has no CSS pipeline,
and `sideEffects: false` in `package.json` lets consumers' bundlers drop a CSS import entirely.
Both download paths (`downloadAsSVG`, `downloadSVGAsPNG`) run `XMLSerializer` over the SVG
element, so an inline `<style>` survives serialization where an external sheet would not.

Duplicating the rule per cell instead of once per chart measures worse on every axis
(4,900 cells): mount 8.9 → 12.6 ms, heap 3.93 → 5.01 MB, DOM nodes 9,807 → 14,706, style recalc
1.87 → 2.99 ms.

**Incidental bug fix:** the previous `transition: stroke-width 0.2s` sat on the `<g>` wrapper.
`transition` is not an inherited property and the `<rect>` inside carried only `cursor`, so the
outline snapped instantly — the transition never worked. It is now on the shape and does animate.

---

## 2. One tooltip per chart, not one per cell

New generic `src/tooltip/PlotTooltip.tsx`, rendered as a **sibling** of the grid and driven
through a ref:

```tsx
const tooltipRef = useRef<PlotTooltipHandle<AnyBin>>(null);
…
<HeatmapComponent>{cells}</HeatmapComponent>
{tooltipBody && <PlotTooltip ref={tooltipRef}>{tooltipBody}</PlotTooltip>}
```

with each cell doing `onMouseMove={(e) => tooltipRef.current?.show(bin, e)}`.

The rule this encodes: **tooltip state must not live in an ancestor of the marks.** Chart-level
state violates it (every mark re-renders). Per-mark state satisfies it, but costs one state hook
and one portal per mark. A sibling satisfies it at a fixed cost of one.

Worth noting for reviewers: this is not a visx anti-pattern. visx examples put `useTooltip` at
chart level because those examples have a single hit area (an overlay rect + `localPoint`), not N
independently hoverable marks. `Histogram/HistogramTooltip.tsx` already uses this same ref shape.

**`show` takes the datum, not rendered output.** That means marks never receive `tooltipBody` at
all, so an unstable one from a consumer cannot invalidate them — and it makes the call lazy.
Rendering a 400-cell grid now calls `tooltipBody` **0 times**; hovering one cell calls it **once**.
Previously every cell built a `ReactElement` that was thrown away unless that cell was hovered.

**On dropping `useTooltip`:** this is not where the speedup comes from, and shouldn't be defended
as such — `useTooltip` is one `useState` plus two `useCallback`, and keeping it inside
`PlotTooltip` performs identically. It was dropped because it had nothing left to do: our handle
is `show(data, event)` and its API is `showTooltip({ tooltipLeft, tooltipTop, tooltipData })`, so
wrapping it means translating coordinates and renaming three fields, then never touching
`updateTooltip` or the functional-update overload. We still use `Portal` and `TooltipWithBounds`
from `@visx/tooltip`, which is where the real value is (viewport-edge flipping and positioning).

`PlotTooltipRef<T>` is exported so mark components can write `tooltipRef: PlotTooltipRef<AnyBin>`
instead of `RefObject<PlotTooltipHandle<AnyBin> | null>` — the `| null` is required and easy to
get wrong.

---

## 3. The `memo` on `HeatmapCell` was inert; it now has a comparator

visx builds every bin as a fresh object literal inside its own render:

```js
bins(datum).map((bin, row) => ({ bin, row, column, datum, width, height, … }))
```

There are no hooks anywhere in `@visx/heatmap` — verified by grepping the shipped build — so the
`bin` prop always arrives with a new identity and the default shallow compare can never bail out.
Confirmed at runtime by rendering `HeatmapRect` three times with identical props:

```
binObjectSameIdentity:        false   ← the prop passed to HeatmapCell
binFieldsDeepEqual:           true    ← contents identical
innerRowDatumSameIdentity:    true    ← bin.bin  keeps identity
innerColumnDatumSameIdentity: true    ← bin.datum keeps identity
```

Those last two are what make a comparator clean: compare the derived scalars, identity-check the
two references back into the caller's own data.

`binsEqual` compares the full field set — including `color`, `opacity` and `gap`, not just
geometry. A cell that skips re-rendering keeps the bin object it closes over, and that same object
is handed to `onClick` and the tooltip, so a field omitted here could go stale there even if the
cell looked correct. Rect and circle bins carry different geometry, so there is an `in`-narrowed
branch for each.

---

## 4. Stabilizing consumer props

Two props were still forcing full-grid work on every render of the consumer. Both matter because
this ships as a library — consumers will not necessarily have the React Compiler enabled, so
inline arrows and array literals arrive with fresh identity each render.

**`onClick`** — new `useStableCallback` in `src/hooks/`. It forwards through a ref updated in a
`useLayoutEffect` rather than during render, since a render can be discarded under concurrent
rendering; the layout effect commits before the browser can dispatch the next event, so the ref is
always current by the time the handler can fire.

This is complementary to §3: the comparator is what lets cells bail out, and stabilizing `onClick`
is what lets the comparator ever return `true`.

**`colors`** — after the above, this was the single remaining thing rebuilding the grid. The
compiled output showed the memo guards had narrowed to:

```js
// cells arrow — all stable
if ($[15] !== animationType || $[16] !== binWidth || $[17] !== deselectedColor
    || $[18] !== handleClick || $[19] !== isRect || $[20] !== selectedKeys) {
// grid element
if (… $[23] !== colorScale || $[24] !== data …) {
```

`colorScale` derives from `colors`, and every story passes `colors` as an inline array literal.
Fixed by keying on contents:

```tsx
const colorsKey = colors.join("\u0000");
const stableColors = useMemo(() => colorsKey.split("\u0000") as [...], [colorsKey]);
```

Two details behind that spelling. The React Compiler **ignores the dependency array and re-infers
deps from the function body**, so the usual "lie in the deps" trick doesn't work — the value
itself has to be stable, which means the body may only read `colorsKey`. And the separator is NUL
rather than a comma because CSS colors legitimately contain commas (`rgb(10, 20, 30)`); there's a
test for that.

---

## 5. `data={[]}` crashed

`data[0].rows` threw `Cannot read properties of undefined (reading 'rows')`. Reproduced in a
browser. Fixed in three parts:

- `maxOf` used `Math.max(...data.map(value))`, which returns `-Infinity` for an empty array (and
  has an argument-count ceiling) — now a `reduce` seeded at 0.
- `data[0].rows` → `data[0]?.rows ?? []` in both places.
- The existing "don't render at a negative size" guard now also covers
  `data.length === 0 || numRows === 0`, so a column list with no rows can't produce a non-finite
  `binHeight`.

Also gave `useImperativeHandle` a `[downloadFileName]` dep array; it was rebuilding the download
handle on every render.

---

## 6. Merging `allow null values`, and one fix on top

Two conflicts, both where the null-value work overlapped these changes:

- **`maxOf`** — both sides had rewritten it. Theirs filters null counts out of the max; this
  branch had replaced `Math.max(...spread)` so empty input yields 0 rather than `-Infinity` (and
  there's no argument-count ceiling). Both concerns are real, so the resolution does both in one
  `reduce`. Taking either side alone loses something.
- **The cell render in `HeatmapCells`** — kept their `isNullValue` fill/opacity logic, kept this
  branch's `tooltipRef` / `handleClick` props and the `PlotTooltip` sibling.

`types.ts` (`count: number | null`) and the new `WithNullValues` story merged cleanly. The §3
comparator handles null counts as-is (`a.count !== b.count`).

**Fix on top: null cells weren't hit-testable.** Cells with a null count render `fill="none"`, and
SVG's default `pointer-events: visiblePainted` only treats *painted* area as a hit target — so the
pointer fell through to the `<svg>` and those cells could never be hovered or clicked. That makes
the `{bin?.count ?? 'No data'}` branch of the new story's `tooltipBody` unreachable. Verified as
pre-existing on `heatmpaImprovemtns` rather than a merge artifact, by probing that branch directly:

```
before →  nullCell: { fill: "none", hitTarget: "svg" }
after  →  nullCell: { fill: "none", hitTarget: "rect.visx-heatmap-cell-shape" }
```

One line, in the stylesheet from §1: `pointer-events: all` on the cell shape, which makes
hit-testing independent of whether the fill is painted. No effect on cells that already had one.
Chosen over changing `NULL_VALUE_COLOR` to `"transparent"` because it keeps the change in CSS this
branch already owns and states the rule directly — a cell is interactive because it is a cell.

Null cells still render unpainted, and still show no hover outline, since their stroke is `"none"`
too. Whether a "no data" cell *should* highlight on hover is a design call on that feature, so it's
left as-is.

---

## Measurements

Real components in headless Chromium, production builds, React Compiler on, medians of repeated
runs. The two tables below are **separate experiments with their own baselines** — don't chain the
numbers precisely, though the cumulative effect on an unrelated parent re-render is roughly
13 ms → 2 ms at 4,900 cells.

**Comparator + `onClick` stabilization** (4,900 cells, consumer passing inline `onClick` and
`tooltipBody`):

| | baseline | after |
|---|---|---|
| add one cell to selection | 11.85 ms | 6.12 ms |
| unrelated parent re-render | 13.11 ms | 7.61 ms |
| full data swap | 14.42 ms | 16.13 ms |

**`colors` stabilization** (same scenario): unrelated parent re-render 6.65 ms → **2.14 ms**.

The full-data-swap row is the honest counterweight: when every cell genuinely changes, the
comparator saves nothing and costs ~1.7 ms running 4,900 comparisons that all return false. That
is the price of the approach.

---

## Caveats and follow-ups

- **A consumer who rebuilds `data` inline on every render gets none of the §3/§4 benefit** — that
  invalidates `bin.bin` identity and defeats the comparator. The existing stories hold data at
  module scope, which is correct. This probably deserves a line in the prop docs.
- `cellPropsEqual` must list every prop in `HeatmapCellProps`. One omitted would silently stop
  updating. Noted in a comment above it.
- **Not changed:** `Heatmap.tsx` sizes axis margins with `maxColNameLength * 8`, a character-count
  guess, while its own sibling `HeatmapLegend.tsx` uses the real `measureTextWidth` utility and
  carries a comment about labels being clipped by the SVG's `overflow: hidden`. The same failure
  mode applies to axis labels with wide glyphs. Left alone because switching it changes layout on
  every existing chart — a visual-regression call, not cleanup.
- **Other plots are untouched.** `BarPlot/singleBar`, `TreeMap/SingleNode` and
  `ViolinPlot/singleViolin` still carry per-mark `useTooltip`; `Histogram` keeps its own
  `HistogramTooltip` (same pattern, container-relative coords instead of Portal + page coords).
  `PlotTooltip` is generic and ready for them in a follow-up.

---

## Verification

26 browser checks against the real `Heatmap` component (not a model), all passing:

- hover: idle / hovered / after-leave stroke states, outline color matching fill, cursor
- tooltip: content, follows pointer, hides on leave, exactly one instance in the DOM, absent when
  `tooltipBody` is omitted, and `tooltipBody` called 0 times per grid render / once per hover
- colors: changing the prop repaints cells (the stabilization must not *freeze* colors), colors
  containing commas survive the join, legend gradient tracks the palette, unrelated parent
  re-render repaints nothing
- selection: click fires with the bin, dims others, adds, deselects, clears without leaving cells
  stale-gray; cells update when the underlying data changes
- null values: 80/400 cells render unpainted, stay unpainted across a selection round-trip and a
  data change, are the hit target rather than the `<svg>`, show their "No data" tooltip, and report
  `count: null` to `onClick` — in both rect and circle mode
- circle mode (the other geometry branch in the comparator)
- serialized SVG carries the stylesheet
- `data={[]}`, `data=[{rows: []}]` and all-null data render without throwing

Typecheck and package build clean.
